### PR TITLE
Fix locale comparison in URL parsing logic

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -329,7 +329,7 @@ class LaravelLocalization
         $locale = $this->getLocaleFromMapping($locale);
 
         if (!empty($locale)) {
-            if ($forceDefaultLocation || $locale != $this->getDefaultLocale() || !$this->hideDefaultLocaleInURL()) {
+            if ($forceDefaultLocation || $locale != $this->getLocaleFromMapping($this->getDefaultLocale()) || !$this->hideDefaultLocaleInURL()) {
                 $parsed_url['path'] = $locale.'/'.ltrim($parsed_url['path'], '/');
             }
         }


### PR DESCRIPTION
# .env
APP_LOCALE=en_AE
# config/laravellocalization.php
'localesMapping' => [
        'en_AE' => 'en-ae',
],
'hideDefaultLocaleInURL' => true,
# test
$routeUrl = route('site.home');
$result = LaravelLocalization::localizeURL($routeUrl); $result = 'http://my.site/en-ae';
# must be 
$result = 'http://my.site';